### PR TITLE
Store certificates in database and add custom provider

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,9 @@
 # checks locally.
 inherit_from: ./.rubocop_hound.yml
 
+AllCops:
+  TargetRubyVersion: 2.1
+
 # Use double quotes only for interpolation.
 Style/StringLiterals:
   EnforcedStyle: single_quotes

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem 'activeadmin'
 gem 'state_machine', git: 'https://github.com/codevise/state_machine.git'
 
 gem 'coveralls', require: false

--- a/admin/cert_watch/certificates.rb
+++ b/admin/cert_watch/certificates.rb
@@ -1,7 +1,7 @@
 require 'cert_watch/views/all'
 
 module CertWatch
-  ActiveAdmin.register Certificate do
+  ActiveAdmin.register Certificate, as: 'Certificate' do
     menu priority: 100
 
     actions :index, :new, :create, :show, :edit, :update
@@ -10,7 +10,7 @@ module CertWatch
 
     index do
       column :domain do |certificate|
-        link_to(certificate.domain, admin_cert_watch_certificate_path(certificate))
+        link_to(certificate.domain, admin_certificate_path(certificate))
       end
       column :state do |certificate|
         cert_watch_certificate_state(certificate)
@@ -41,10 +41,10 @@ module CertWatch
       f.actions
     end
 
-    action_item(only: :show) do
+    action_item(:renew, only: :show) do
       if resource.can_renew?
         button_to(I18n.t('cert_watch.admin.certificates.renew'),
-                  renew_admin_cert_watch_certificate_path(resource),
+                  renew_admin_certificate_path(resource),
                   method: :post,
                   data: {
                     rel: 'renew',
@@ -53,10 +53,10 @@ module CertWatch
       end
     end
 
-    action_item(only: :show) do
+    action_item(:install, only: :show) do
       if resource.can_install?
         button_to(I18n.t('cert_watch.admin.certificates.install'),
-                  install_admin_cert_watch_certificate_path(resource),
+                  install_admin_certificate_path(resource),
                   method: :post,
                   data: {
                     rel: 'install',
@@ -68,13 +68,13 @@ module CertWatch
     member_action :renew, method: :post do
       resource = Certificate.find(params[:id])
       resource.renew
-      redirect_to(admin_cert_watch_certificate_path(resource))
+      redirect_to(admin_certificate_path(resource))
     end
 
     member_action :install, method: :post do
       resource = Certificate.find(params[:id])
       resource.install
-      redirect_to(admin_cert_watch_certificate_path(resource))
+      redirect_to(admin_certificate_path(resource))
     end
 
     show title: :domain do |certificate|

--- a/admin/cert_watch/certificates.rb
+++ b/admin/cert_watch/certificates.rb
@@ -4,7 +4,7 @@ module CertWatch
   ActiveAdmin.register Certificate do
     menu priority: 100
 
-    actions :index, :new, :create, :show
+    actions :index, :new, :create, :show, :edit, :update
 
     config.batch_actions = false
 
@@ -29,10 +29,14 @@ module CertWatch
 
     filter :domain
     filter :last_renewed_at
+    filter :provider, as: :select, collection: Certificate::PROVIDERS
 
     form do |f|
       f.inputs do
         f.input :domain
+        f.input :public_key
+        f.input :private_key
+        f.input :chain
       end
       f.actions
     end
@@ -84,12 +88,17 @@ module CertWatch
         row :last_renewal_failed_at
         row :last_installed_at
         row :last_install_failed_at
+        row :public_key
       end
+    end
+
+    before_create do |certificate|
+      certificate.provider = 'custom'
     end
 
     controller do
       def permitted_params
-        params.permit(cert_watch_certificate: [:domain])
+        params.permit(certificate: [:domain, :public_key, :private_key, :chain])
       end
     end
   end

--- a/app/jobs/cert_watch/install_certificate_job.rb
+++ b/app/jobs/cert_watch/install_certificate_job.rb
@@ -5,8 +5,14 @@ module CertWatch
     @queue = :cert_watch
 
     def self.perform_with_result(certificate, _options = {})
-      CertWatch.installer.install(certificate.domain)
+      CertWatch.installer.install(domain: certificate.domain,
+                                  provider: certificate.provider,
+                                  public_key: certificate.public_key,
+                                  private_key: certificate.private_key,
+                                  chain: certificate.chain)
+
       certificate.last_installed_at = Time.now
+
       :ok
     rescue InstallError
       certificate.last_install_failed_at = Time.now

--- a/app/jobs/cert_watch/renew_certificate_job.rb
+++ b/app/jobs/cert_watch/renew_certificate_job.rb
@@ -5,8 +5,11 @@ module CertWatch
     @queue = :cert_watch
 
     def self.perform_with_result(certificate, _options = {})
-      CertWatch.client.renew(certificate.domain)
+      result = CertWatch.client.renew(certificate.domain)
+
+      certificate.attributes = result.slice(:public_key, :private_key, :chain)
       certificate.last_renewed_at = Time.now
+
       :ok
     rescue RenewError
       certificate.last_renewal_failed_at = Time.now

--- a/app/jobs/cert_watch/renew_expiring_certificates_job.rb
+++ b/app/jobs/cert_watch/renew_expiring_certificates_job.rb
@@ -4,6 +4,7 @@ module CertWatch
 
     def self.perform
       Certificate
+        .auto_renewable
         .installed
         .expiring
         .limit(CertWatch.config.renewal_batch_size)

--- a/app/models/cert_watch/certificate.rb
+++ b/app/models/cert_watch/certificate.rb
@@ -1,5 +1,9 @@
 module CertWatch
   class Certificate < ActiveRecord::Base
+    PROVIDERS = %w(certbot custom).freeze
+
+    validates :provider, inclusion: PROVIDERS
+
     state_machine initial: 'not_installed' do
       extend StateMachineJob::Macro
 
@@ -12,6 +16,7 @@ module CertWatch
       end
 
       event :install do
+        transition 'not_installed' => 'installing'
         transition 'installed' => 'installing'
         transition 'installing_failed' => 'installing'
       end
@@ -38,5 +43,30 @@ module CertWatch
     scope(:failed, -> { where(state: %w(renewing_failed installing_failed)) })
     scope(:expiring, -> { where('last_renewed_at < ?', CertWatch.config.renewal_interval.ago) })
     scope(:abandoned, -> { where(state: 'abandoned') })
+
+    scope(:auto_renewable, -> { where.not(provider: 'custom') })
+    scope(:custom, -> { where(provider: 'custom') })
+
+    def can_renew?
+      auto_renewable? && super
+    end
+
+    def can_install?
+      complete? && super
+    end
+
+    def auto_renewable?
+      !custom?
+    end
+
+    def custom?
+      provider == 'custom'
+    end
+
+    def complete?
+      public_key.present? &&
+        private_key.present? &&
+        chain.present?
+    end
   end
 end

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -27,6 +27,10 @@ de:
         confirm_install: "Soll das Zertifikat wirklich installiert werden?"
   activerecord:
     models:
+      # Required for ActiveAdmin navigation
+      certificate:
+        one: "SSL Zertifikat"
+        other: "SSL Zertifikate"
       "cert_watch/certificate":
         one: "SSL Zertifikat"
         other: "SSL Zertifikate"
@@ -39,6 +43,10 @@ de:
         last_renewal_failed_at: "Erneuerung fehlgeschlagen"
         last_installed_at: "Zuletzt installiert"
         last_install_failed_at: "Installation fehlgeschlagen"
+        provider: "Typ"
+        public_key: "Zertifikat"
+        private_key: "Privater Schlüssel"
+        chain: "Zertifikatskette"
   active_admin:
     scopes:
       installed: "Installiert"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -27,6 +27,10 @@ en:
         confirm_install: "Are you sure you want to reinstall this certificate?"
   activerecord:
     models:
+      # Required for ActiveAdmin navigation
+      certificate:
+        one: "SSL Certificate"
+        other: "SSL Certificates"
       "cert_watch/certificate":
         one: "SSL Certificate"
         other: "SSL Certificates"
@@ -39,6 +43,10 @@ en:
         last_renewal_failed_at: "Last failed renewal"
         last_installed_at: "Last installed at"
         last_install_failed_at: "Last failed install"
+        provider: "Type"
+        public_key: "Certificate"
+        private_key: "Private Key"
+        chain: "Intermediate Certificates"
   active_admin:
     scopes:
       installed: "Installed"

--- a/db/migrate/20171023122819_add_key_fields_to_certificates.rb
+++ b/db/migrate/20171023122819_add_key_fields_to_certificates.rb
@@ -1,0 +1,7 @@
+class AddKeyFieldsToCertificates < ActiveRecord::Migration
+  def change
+    add_column :cert_watch_certificates, :public_key, :text
+    add_column :cert_watch_certificates, :private_key, :text
+    add_column :cert_watch_certificates, :chain, :text
+  end
+end

--- a/db/migrate/20171024073152_add_provider_to_certificates.rb
+++ b/db/migrate/20171024073152_add_provider_to_certificates.rb
@@ -1,0 +1,5 @@
+class AddProviderToCertificates < ActiveRecord::Migration
+  def change
+    add_column :cert_watch_certificates, :provider, :string, default: 'certbot', null: false
+  end
+end

--- a/lib/cert_watch.rb
+++ b/lib/cert_watch.rb
@@ -11,11 +11,14 @@ module CertWatch
     yield @config if block_given?
 
     self.client = CertbotClient.new(executable: config.certbot_executable,
-                                    port: config.certbot_port)
+                                    port: config.certbot_port,
+                                    output_directory: config.certbot_output_directory)
 
-    self.installer = PemDirectoryInstaller.new(pem_directory: config.pem_directory,
-                                               input_directory: config.certbot_output_directory,
-                                               reload_command: config.server_reload_command)
+    self.installer =
+      PemDirectoryInstaller
+      .new(pem_directory: config.pem_directory,
+           provider_directory_mapping: config.provider_install_directory_mapping,
+           reload_command: config.server_reload_command)
   end
 
   mattr_accessor :client

--- a/lib/cert_watch/client.rb
+++ b/lib/cert_watch/client.rb
@@ -3,5 +3,9 @@ module CertWatch
     def renew(_domain)
       fail(NotImplementedError)
     end
+
+    def read_outputs(_domain)
+      fail(NotImplementedError)
+    end
   end
 end

--- a/lib/cert_watch/configuration.rb
+++ b/lib/cert_watch/configuration.rb
@@ -19,6 +19,9 @@ module CertWatch
     # Directory the web server reads pem files from
     attr_accessor :pem_directory
 
+    # Directory the web server reads pem files from
+    attr_accessor :provider_install_directory_mapping
+
     # Command to make server reload pem files
     attr_accessor :server_reload_command
 
@@ -31,6 +34,7 @@ module CertWatch
       @certbot_output_directory = '/etc/letsencrypt/live'
 
       @pem_directory = '/etc/haproxy/ssl/'
+      @provider_install_directory_mapping = {}
       @server_reload_command = '/etc/init.d/haproxy reload'
     end
   end

--- a/lib/cert_watch/domain_owner.rb
+++ b/lib/cert_watch/domain_owner.rb
@@ -13,7 +13,11 @@ module CertWatch
               new_value = self[attribute]
 
               Certificate.find_by(domain: previous_value).try(:abandon)
-              Certificate.find_or_create_by(domain: new_value).renew if new_value.present?
+
+              if new_value.present?
+                certificate = Certificate.find_or_create_by(domain: new_value)
+                certificate.renew! if certificate.auto_renewable?
+              end
             end
           end
         end

--- a/lib/cert_watch/installer.rb
+++ b/lib/cert_watch/installer.rb
@@ -1,5 +1,5 @@
 module CertWatch
-  class PemDirectoryInstaller < Installer
+  class Installer
     def install(_domain)
       fail(NotImplementedError)
     end

--- a/lib/cert_watch/shell.rb
+++ b/lib/cert_watch/shell.rb
@@ -4,10 +4,15 @@ module CertWatch
 
     class CommandFailed < Error; end
 
+    def sudo_read(file_name)
+      sudo("cat #{file_name}")
+    end
+
     def sudo(command)
       output, input = IO.pipe
+      env = 'LANG=en '
       prefix = !Rails.env.test? ? 'sudo ' : ''
-      full_command = [prefix, command].join
+      full_command = [env, prefix, command].join
 
       result = system(full_command, [:out, :err] => input)
       input.close
@@ -15,6 +20,8 @@ module CertWatch
       unless result
         fail(CommandFailed, "Command '#{full_command}' failed with output:\n\n#{output.read}\n")
       end
+
+      output.read
     end
   end
 end

--- a/lib/cert_watch/tasks.rb
+++ b/lib/cert_watch/tasks.rb
@@ -5,9 +5,9 @@ module CertWatch
     extend Rake::DSL
 
     namespace :cert_watch do
-      namespace reinstall: :environment do
+      namespace :reinstall do
         desc 'Rewrite certificate files from database contents.'
-        task :all do
+        task all: :environment do
           Certificate.installed.each(&:install)
         end
       end

--- a/lib/cert_watch/tasks.rb
+++ b/lib/cert_watch/tasks.rb
@@ -5,7 +5,7 @@ module CertWatch
     extend Rake::DSL
 
     namespace :cert_watch do
-      namespace :reinstall do
+      namespace reinstall: :environment do
         desc 'Rewrite certificate files from database contents.'
         task :all do
           Certificate.installed.each(&:install)
@@ -14,7 +14,7 @@ module CertWatch
 
       namespace :import do
         desc 'Read certbot outputs for all certificates and store in database.'
-        task :certbot do
+        task certbot: :environment do
           Certificate.auto_renewable.installed.each do |certificate|
             result = CertWatch.client.read_outputs(certificate.domain)
             certificate.update!(result.slice(:public_key, :private_key, :chain))

--- a/lib/cert_watch/tasks.rb
+++ b/lib/cert_watch/tasks.rb
@@ -1,0 +1,26 @@
+require 'rake'
+
+module CertWatch
+  module Tasks
+    extend Rake::DSL
+
+    namespace :cert_watch do
+      namespace :reinstall do
+        desc 'Rewrite certificate files from database contents.'
+        task :all do
+          Certificate.installed.each(&:install)
+        end
+      end
+
+      namespace :import do
+        desc 'Read certbot outputs for all certificates and store in database.'
+        task :certbot do
+          Certificate.auto_renewable.installed.each do |certificate|
+            result = CertWatch.client.read_outputs(certificate.domain)
+            certificate.update!(result.slice(:public_key, :private_key, :chain))
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/cert_watch/domain_owner_spec.rb
+++ b/spec/cert_watch/domain_owner_spec.rb
@@ -20,6 +20,27 @@ module CertWatch
       expect(certificate.state).to eq('renewing')
     end
 
+    it 'does not create certificate of custom certificate exists' do
+      create(:certificate,
+             state: 'installed',
+             provider: 'custom',
+             domain: 'custom.example.com')
+
+      expect do
+        test_domain_owner_model.create!(cname: 'custom.example.com')
+      end.not_to change { Certificate.count }
+    end
+
+    it 'does not renew existing custom certificate' do
+      certificate = create(:certificate,
+                           state: 'installed',
+                           provider: 'custom',
+                           domain: 'custom.example.com')
+      test_domain_owner_model.create!(cname: 'custom.example.com')
+
+      expect(certificate.reload.state).to eq('installed')
+    end
+
     it 'renews certificate on update' do
       domain_owner = test_domain_owner_model.create!(cname: 'old.example.com')
 

--- a/spec/cert_watch/shell_spec.rb
+++ b/spec/cert_watch/shell_spec.rb
@@ -9,10 +9,34 @@ module CertWatch
         expect(File.read('foo')).to eq("test\n")
       end
 
+      it 'returns output as strigng' do
+        Fixtures.file('foo', "CONTENTS\n")
+
+        result = Shell.sudo('cat foo')
+
+        expect(result).to eq("CONTENTS\n")
+      end
+
       it 'raises CommandFailed with output if command fails' do
         expect do
           Shell.sudo('LANG=en touch not/there')
         end.to raise_error(Shell::CommandFailed, /cannot touch/)
+      end
+    end
+
+    describe '.sudo_read' do
+      it 'returns file content' do
+        Fixtures.file('foo', "CONTENTS\n")
+
+        result = Shell.sudo_read('foo')
+
+        expect(result).to eq("CONTENTS\n")
+      end
+
+      it 'raises CommandFailed if file is missing' do
+        expect do
+          Shell.sudo_read('not/there')
+        end.to raise_error(Shell::CommandFailed, /No such file/)
       end
     end
   end

--- a/spec/cert_watch/tasks_spec.rb
+++ b/spec/cert_watch/tasks_spec.rb
@@ -4,6 +4,8 @@ require 'cert_watch/tasks'
 require 'support/helpers/doubles'
 require 'support/helpers/inline_resque'
 
+Rake::Task.define_task(:environment)
+
 RSpec.describe 'tasks', fixture_files: true, inline_resque: true do
   describe 'cert_watch:reinstall:all' do
     it 'reinstalls installed certificates' do

--- a/spec/cert_watch/tasks_spec.rb
+++ b/spec/cert_watch/tasks_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+require 'cert_watch/tasks'
+
+require 'support/helpers/doubles'
+require 'support/helpers/inline_resque'
+
+RSpec.describe 'tasks', fixture_files: true, inline_resque: true do
+  describe 'cert_watch:reinstall:all' do
+    it 'reinstalls installed certificates' do
+      create(:certificate, state: 'installed', domain: 'some.example.com')
+
+      Rake.application['cert_watch:reinstall:all'].invoke
+
+      expect(CertWatch.installer).to have_received(:install)
+        .with(hash_including(domain: 'some.example.com'))
+    end
+  end
+
+  describe 'cert_watch:import:certbot' do
+    it 'imports installed auto renewable certificates' do
+      certificate = create(:certificate, :auto_renewable, state: 'installed')
+
+      Rake.application['cert_watch:import:certbot'].invoke
+      certificate.reload
+
+      expect(certificate.public_key).to be_present
+      expect(certificate.private_key).to be_present
+      expect(certificate.chain).to be_present
+    end
+  end
+end

--- a/spec/controllers/admin/cert_watch/certificates_controller_spec.rb
+++ b/spec/controllers/admin/cert_watch/certificates_controller_spec.rb
@@ -1,7 +1,60 @@
 require 'rails_helper'
 
 module Admin
-  RSpec.describe CertWatchCertificatesController, type: :controller do
+  RSpec.describe CertificatesController, type: :controller do
+    describe '#index' do
+      render_views
+
+      it 'renders table with certificate domains' do
+        create(:certificate, :custom, domain: 'some-custom.example.com')
+        create(:certificate, :auto_renewable)
+
+        get(:index)
+
+        expect(response.body).to have_selector('td a', text: 'some-custom.example.com')
+      end
+    end
+
+    describe '#show' do
+      render_views
+
+      it 'displays renew button for auto renewable certificate' do
+        certificate = create(:certificate, :auto_renewable)
+
+        get(:show, id: certificate)
+
+        expect(response.body).to have_selector('[data-rel=renew]')
+      end
+
+      it 'displays install button for complete certificate' do
+        certificate = create(:certificate, :custom, :complete)
+
+        get(:show, id: certificate)
+
+        expect(response.body).to have_selector('[data-rel=install]')
+      end
+    end
+
+    describe '#renew' do
+      it 'renews certificate' do
+        certificate = create(:certificate, :auto_renewable)
+
+        post(:renew, id: certificate)
+
+        expect(certificate.reload.state).to eq('renewing')
+      end
+    end
+
+    describe '#install' do
+      it 'installs certificate' do
+        certificate = create(:certificate, :complete, :auto_renewable)
+
+        post(:install, id: certificate)
+
+        expect(certificate.reload.state).to eq('installing')
+      end
+    end
+
     describe '#create' do
       it 'creates custom certificate' do
         post(:create, certificate: {

--- a/spec/controllers/admin/cert_watch/certificates_controller_spec.rb
+++ b/spec/controllers/admin/cert_watch/certificates_controller_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+module Admin
+  RSpec.describe CertWatchCertificatesController, type: :controller do
+    describe '#create' do
+      it 'creates custom certificate' do
+        post(:create, certificate: {
+               domain: 'test.example.com',
+               public_key: 'PUBLIC',
+               private_key: 'PRIVATE',
+               chain: 'CHAIN'
+             })
+
+        expect(CertWatch::Certificate.custom.where(domain: 'test.example.com')).to exist
+      end
+    end
+  end
+end

--- a/spec/factories/certificates.rb
+++ b/spec/factories/certificates.rb
@@ -1,6 +1,23 @@
+
+require 'support/helpers/doubles'
+
 FactoryGirl.define do
   factory(:certificate, class: CertWatch::Certificate) do
     domain 'some.example.com'
     state 'not_installed'
+
+    trait :complete do
+      public_key Doubles::PUBLIC_KEY
+      private_key Doubles::PRIVATE_KEY
+      chain Doubles::CHAIN
+    end
+
+    trait :auto_renewable do
+      provider 'certbot'
+    end
+
+    trait :custom do
+      provider 'custom'
+    end
   end
 end

--- a/spec/internal/app/controllers/application_controller.rb
+++ b/spec/internal/app/controllers/application_controller.rb
@@ -1,0 +1,2 @@
+class ApplicationController < ActionController::Base
+end

--- a/spec/internal/config/initializers/active_admin.rb
+++ b/spec/internal/config/initializers/active_admin.rb
@@ -1,0 +1,1 @@
+ActiveAdmin.application.load_paths.unshift(CertWatch.active_admin_load_path)

--- a/spec/internal/config/routes.rb
+++ b/spec/internal/config/routes.rb
@@ -1,3 +1,3 @@
 Rails.application.routes.draw do
-  #
+  ActiveAdmin.routes(self)
 end

--- a/spec/models/cert_watch/certificate_spec.rb
+++ b/spec/models/cert_watch/certificate_spec.rb
@@ -5,6 +5,74 @@ require 'support/helpers/inline_resque'
 
 module CertWatch
   RSpec.describe Certificate, inline_resque: true do
+    describe '.auto_renewable' do
+      it 'includes auto renewable certificates' do
+        certificate = create(:certificate, :auto_renewable)
+
+        expect(Certificate.auto_renewable).to include(certificate)
+      end
+
+      it 'does not include custom certificates' do
+        certificate = create(:certificate, :custom)
+
+        expect(Certificate.auto_renewable).not_to include(certificate)
+      end
+    end
+
+    describe '.custom' do
+      it 'includes custom certificates' do
+        certificate = create(:certificate, :custom)
+
+        expect(Certificate.custom).to include(certificate)
+      end
+
+      it 'does not include auto renewable certificates' do
+        certificate = create(:certificate, :auto_renewable)
+
+        expect(Certificate.custom).not_to include(certificate)
+      end
+    end
+
+    describe 'can_renew?' do
+      it 'returns true for auto renewable certificate' do
+        certificate = create(:certificate, :auto_renewable)
+
+        expect(certificate.can_renew?).to eq(true)
+      end
+
+      it 'returns false for custom certificate' do
+        certificate = create(:certificate, :custom)
+
+        expect(certificate.can_renew?).to eq(false)
+      end
+    end
+
+    describe 'can_install?' do
+      it 'returns true for complete installed auto renewable certificate' do
+        certificate = create(:certificate, :auto_renewable, :complete, state: 'installed')
+
+        expect(certificate.can_install?).to eq(true)
+      end
+
+      it 'returns false for not_installed auto renewable certificate' do
+        certificate = create(:certificate, :auto_renewable, state: 'not_installed')
+
+        expect(certificate.can_install?).to eq(false)
+      end
+
+      it 'returns false for complete custom certificate' do
+        certificate = create(:certificate, :custom, :complete)
+
+        expect(certificate.can_install?).to eq(true)
+      end
+
+      it 'returns false for incomplete custom certificate' do
+        certificate = create(:certificate, :custom)
+
+        expect(certificate.can_install?).to eq(false)
+      end
+    end
+
     describe '#renew' do
       it 'makes client renew certificate for domain' do
         certificate = create(:certificate, domain: 'my.example.com')
@@ -15,11 +83,18 @@ module CertWatch
       end
 
       it 'installs certificate' do
-        certificate = create(:certificate, domain: 'my.example.com')
+        certificate = create(:certificate,
+                             provider: 'certbot',
+                             domain: 'my.example.com')
 
         certificate.renew!
 
-        expect(CertWatch.installer).to have_received(:install).with('my.example.com')
+        expect(CertWatch.installer).to have_received(:install)
+          .with(domain: 'my.example.com',
+                provider: 'certbot',
+                public_key: Doubles::PUBLIC_KEY,
+                private_key: Doubles::PRIVATE_KEY,
+                chain: Doubles::CHAIN)
       end
 
       it 'sets state to installed' do
@@ -28,6 +103,17 @@ module CertWatch
         certificate.renew!
 
         expect(certificate.reload.state).to eq('installed')
+      end
+
+      it 'stores keys' do
+        certificate = create(:certificate,
+                             domain: 'my.example.com')
+
+        certificate.renew!
+
+        expect(certificate.reload.public_key).to be_present
+        expect(certificate.reload.private_key).to be_present
+        expect(certificate.reload.chain).to be_present
       end
 
       it 'updates last_renewed_at attribute' do
@@ -93,6 +179,68 @@ module CertWatch
                                last_install_failed_at: 1.month.ago)
 
           certificate.renew!
+
+          expect(certificate.reload.last_install_failed_at).to eq(Time.now)
+        end
+      end
+    end
+
+    describe '#install' do
+      it 'installs certificate' do
+        certificate = create(:certificate,
+                             :complete,
+                             provider: 'custom',
+                             domain: 'my.example.com')
+
+        certificate.install!
+
+        expect(CertWatch.installer).to have_received(:install)
+          .with(domain: 'my.example.com',
+                provider: 'custom',
+                public_key: Doubles::PUBLIC_KEY,
+                private_key: Doubles::PRIVATE_KEY,
+                chain: Doubles::CHAIN)
+      end
+
+      it 'sets state to installed' do
+        certificate = create(:certificate, :complete, domain: 'my.example.com')
+
+        certificate.install!
+
+        expect(certificate.reload.state).to eq('installed')
+      end
+
+      it 'updates last_installed_at attribute' do
+        certificate = create(:certificate,
+                             :complete,
+                             domain: 'my.example.com',
+                             last_installed_at: 1.month.ago)
+
+        certificate.install!
+
+        expect(certificate.reload.last_installed_at).to eq(Time.now)
+      end
+
+      context 'when install results in error' do
+        before do
+          CertWatch.installer = Doubles.failing_installer
+        end
+
+        it 'sets state to installing_failed' do
+          certificate = create(:certificate, :complete, domain: 'my.example.com')
+
+          certificate.install!
+
+          expect(certificate.reload.state).to eq('installing_failed')
+        end
+
+        it 'updates last_install_failed_at attribute' do
+          certificate = create(:certificate,
+                               :complete,
+                               domain: 'my.example.com',
+                               last_install_failed_at: 1.month.ago)
+
+          certificate.install!
 
           expect(certificate.reload.last_install_failed_at).to eq(Time.now)
         end

--- a/spec/support/config/cert_watch.rb
+++ b/spec/support/config/cert_watch.rb
@@ -1,3 +1,5 @@
+require 'support/helpers/doubles'
+
 RSpec.configure do |config|
   config.before do
     CertWatch.setup

--- a/spec/support/helpers/doubles.rb
+++ b/spec/support/helpers/doubles.rb
@@ -2,9 +2,19 @@ module Doubles
   extend RSpec::Mocks::ExampleMethods
   extend self
 
+  PUBLIC_KEY = "PUBLIC KEY\n".freeze
+  PRIVATE_KEY = "PRIVATE KEY\n".freeze
+  CHAIN = "CHAIN\n".freeze
+
   def client
     instance_double('CertWatch::Client').tap do |double|
-      allow(double).to receive(:renew).and_return(:ok)
+      allow(double).to receive(:renew).and_return(public_key: PUBLIC_KEY,
+                                                  private_key: PRIVATE_KEY,
+                                                  chain: CHAIN)
+
+      allow(double).to receive(:read_outputs).and_return(public_key: PUBLIC_KEY,
+                                                         private_key: PRIVATE_KEY,
+                                                         chain: CHAIN)
     end
   end
 


### PR DESCRIPTION
* Read certbot generated files and store certificates in database.

* Allow creating custom certificates with manually entered certificate
  information.

* Add Rake task to reinstall all certificates from the database-

* Add Rake task to read installed certificates from the certbot output
  directory to upgrade a previous `cert_watch` install.