### PR TITLE
Turn lib into eager load path

### DIFF
--- a/lib/cert_watch/engine.rb
+++ b/lib/cert_watch/engine.rb
@@ -5,6 +5,6 @@ module CertWatch
   class Engine < ::Rails::Engine
     isolate_namespace CertWatch
 
-    config.autoload_paths << File.join(config.root, 'lib')
+    config.paths.add('lib', eager_load: true)
   end
 end


### PR DESCRIPTION
Files on the autoload path are no longer automatically available in
production.